### PR TITLE
Add CI and fix bug with recursive phantom dependency

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = .git, tools, examples

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 exclude = .git, tools, examples
+max_line_length = 127

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Set up Python 3.10.5
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.10.5
+          cache: pip # caching pip dependencies
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
@@ -24,6 +25,3 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest
-        run: |
-          pytest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up Python 3.10.5
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10.5
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest

--- a/phantom/__init__.py
+++ b/phantom/__init__.py
@@ -8,6 +8,6 @@ import phantom.measures
 import phantom.similarity
 import phantom.utils
 import phantom.video
+from importlib.metadata import version
 
-__version__ = "0.8.3" 
-
+__version__ = version("phantom")

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,9 @@
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License along with this program; if not,
-# write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+# write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 from setuptools import setup, find_packages
-import phantom
 
 long_desc = """
 A digital image processing library aimed at digital forensic experts, to help
@@ -21,22 +20,20 @@ them work over photographic, video (or other source media) elements.
 """
 
 setup(
-    name = "phantom",
-    version = phantom.__version__,
-    description = "forensic digital image processing in python",
-    long_description = long_desc,
-    author = "Bruno Constanzo",
-    author_email = "bconstanzo@ufasta.edu.ar",
-    url = "https://github.com/bconstanzo/phantom",
-    license = "LGPL 2.1",
-    install_requires = [
-        "numpy", "scipy", "scikit-learn", "dlib", 
-        #"opencv-python",  # you may need to comment this one for Anaconda compatibility
+    name="phantom",
+    version="0.8.3",
+    description="forensic digital image processing in python",
+    long_description=long_desc,
+    author="Bruno Constanzo",
+    author_email="bconstanzo@ufasta.edu.ar",
+    url="https://github.com/bconstanzo/phantom",
+    license="LGPL 2.1",
+    install_requires=[
+        "numpy", "scipy", "scikit-learn", "dlib",
+        # "opencv-python",  # you may need to comment this one for Anaconda compatibility
         ],
     python_requires='>=3.6',
-    packages = find_packages(),
-    #packages = ['phantom'],
+    packages=find_packages(),
     package_dir={'phantom': 'phantom'},
     package_data={'phantom': ['models/*.dat']},
-#
     )


### PR DESCRIPTION
This PR provides two related things:
1. Adds support for Continuous integration (CI) through Github Workflows.
2. Fixes a bug where phantom tries to import itself in it's `setup.py` making it imposible to install it as a pip dependency.

## Continuous Integration

This PR adds continuous integration. The CI script is located in `.github/workflows/build.yaml`. The script first setups an specific python version, then installs all the `requirements.txt` and then lints the files located in the `./phantom/` subdirectory using `flake8` (Feel free to change it to other linter if you want)

Files located in `./examples/` or `./tools/` are not currently linted. It would be ideal to have those linted too in the future. 

A `.flake8` file is added with minimal configuration. Feel free to add more options or adjust to your coding style. It's recomended to also install the [Flake8 Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.flake8) to get linting while coding. 

## Bug with recursive dependency

This PR removes the `import phantom` at the top of the `setup.py` file. This is important because when installing
phantom as a pip dependency, the `setup.py` file is executed and python tries to import the module phantom, but it does
not exists yet because it's the module we are currently trying to install with pip. This causes an error similar to this one:

```
Installing collected packages: iniconfig, tomli, pyparsing, pyflakes, pycodestyle, py, pluggy, mccabe, attrs, packaging, flake8, pytest
Successfully installed attrs-22.1.0 flake8-5.0.4 iniconfig-1.1.1 mccabe-0.7.0 packaging-21.3 pluggy-1.0.0 py-1.11.0 pycodestyle-2.9.1 pyflakes-2.5.0 pyparsing-3.0.9 pytest-7.1.3 tomli-2.0.1
Processing ./phantom
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/runner/work/phantom-desktop/phantom-desktop/phantom/setup.py", line 16, in <module>
          import phantom
        File "/home/runner/work/phantom-desktop/phantom-desktop/phantom/phantom/__init__.py", line 1, in <module>
          import numpy as np  # so cv2 won't throw random errors if there's no prior install
      ModuleNotFoundError: No module named 'numpy'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Error: Process completed with exit code 1.
```

In this PR, the version number is moved to the setup.py and the version for phantom is fetched in `__init__.py` from the `setup.py` itself.
This removes the need to `import phantom` from `setup.py` so now it can be installed as a pip dependency. 

This has been tested in the [phantom desktop](https://github.com/jhm-ciberman/phantom-desktop) repository using the following setup: 
1. "Phantom" is cloned as a git submodule (pointing to the last commit of this PR)
2. `pip install ./phantom`
3. The setup script runs successfully whereas before it crashed.

The same steps were reproduced in continuous integration. You can check the logs here: 
- [Failing run before the fix](https://github.com/jhm-ciberman/phantom-desktop/runs/8281610547)
- [Fixed run after the fix](https://github.com/jhm-ciberman/phantom/runs/8282177649)

